### PR TITLE
Update regex to be able to publish rc packages

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Bless.MixProject do
 
   @version_file Path.join(__DIR__, ".version")
   @external_resource @version_file
-  @version (case Regex.run(~r/^v([\d\.]+)/, File.read!(@version_file),
+  @version (case Regex.run(~r/^v([\d\.\w-]+)/, File.read!(@version_file),
                    capture: :all_but_first
                  ) do
               [version] -> version


### PR DESCRIPTION
without this regex change, it would've cut off the `-rc1` part and published that as the version, and we don't want a full version yet